### PR TITLE
[Feature] 판매글 중 키워드 검색을 위한 API 구현 close #11

### DIFF
--- a/src/main/java/kr/warmlink/application/article/dto/ArticleDto.java
+++ b/src/main/java/kr/warmlink/application/article/dto/ArticleDto.java
@@ -89,4 +89,34 @@ public class ArticleDto {
                     .build();
         }
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(name = "ArticleDto.SearchResponse", description = "검색 결과 반환을 위한 응답 DTO")
+    public static class SearchResponse {
+        @Schema(description = "게시글 id", example = "1")
+        private Long id;
+
+        @Schema(description = "게시글 제목", example = "초상화 그려드립니다.")
+        private String title;
+
+        @Schema(description = "작성자", example = "홍길동")
+        private String name;
+
+        @Schema(description = "작성일", example = "2025-06-26")
+        private LocalDateTime createdAt;
+
+        public static List<SearchResponse> from(List<Article> articles) {
+            return articles.stream()
+                    .filter(article -> article.isDeleted() == false)
+                    .map(article -> SearchResponse.builder()
+                            .id(article.getId())
+                            .name(article.getUser().getName())
+                            .title(article.getTitle())
+                            .createdAt(article.getCreatedAt())
+                            .build())
+                    .collect(Collectors.toUnmodifiableList());
+        }
+    }
 }

--- a/src/main/java/kr/warmlink/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/kr/warmlink/domain/article/repository/ArticleRepository.java
@@ -2,6 +2,13 @@ package kr.warmlink.domain.article.repository;
 
 import kr.warmlink.domain.article.entity.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
+    @Query("SELECT a FROM article a WHERE a.title LIKE %:keyword%")
+    List<Article> findByKeyword(@Param("keyword") String keyword);
+
 }

--- a/src/main/java/kr/warmlink/domain/article/service/ArticleService.java
+++ b/src/main/java/kr/warmlink/domain/article/service/ArticleService.java
@@ -92,4 +92,14 @@ public class ArticleService {
 
         return ArticleDto.DetailResponse.from(article, article.getUser());
     }
+
+    @Transactional
+    public List<ArticleDto.SearchResponse> search(HttpServletRequest request, String keyword) {
+        String accessToken = jwtProvider.resolveToken(request);
+        String email = jwtProvider.getEmail(accessToken);
+
+        List<Article> result = articleRepository.findByKeyword(keyword);
+
+        return ArticleDto.SearchResponse.from(result);
+    }
 }

--- a/src/main/java/kr/warmlink/presentation/api/ArticleApi.java
+++ b/src/main/java/kr/warmlink/presentation/api/ArticleApi.java
@@ -9,6 +9,7 @@ import kr.warmlink.application.article.dto.ArticleDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "[판매글 관련 API]", description = "사용자 판매글 관련 API")
 public interface ArticleApi {
@@ -46,5 +47,12 @@ public interface ArticleApi {
             @ApiResponse(responseCode = "400", description = "판매글 세부 조회 실패")
     })
     ResponseEntity<?> detail(HttpServletRequest request, @PathVariable Long id);
+
+    @Operation(summary = "판매글 키워드 검색", description = "특정 키워드를 검색했을 때, 게시글 목록 조회를 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "판매글 검색 성공"),
+            @ApiResponse(responseCode = "400", description = "판매글 검색 실패")
+    })
+    ResponseEntity<?> searchKeyword(HttpServletRequest request, @RequestParam String keyword);
 
 }

--- a/src/main/java/kr/warmlink/presentation/controller/ArticleController.java
+++ b/src/main/java/kr/warmlink/presentation/controller/ArticleController.java
@@ -49,4 +49,9 @@ public class ArticleController implements ArticleApi {
         return ResponseEntity.ok(articleService.detail(request, id));
     }
 
+    @Override
+    @GetMapping("/search")
+    public ResponseEntity<?> searchKeyword(HttpServletRequest request, String keyword) {
+        return ResponseEntity.ok(articleService.search(request, keyword));
+    }
 }


### PR DESCRIPTION
## Motivation
<!-- 작성 배경 -->
- 여러개의 판매글 중에서 사용자들이 원하는 판매글을 쉽게 찾기 위하여 키워드 검색 API 필요

## Problem Solving
<!-- 해결 방법 -->
- 사용자가 검색창을 통해 원하는 검색어를 입력(`ex. 그림 → DB에서 LIKE 연산자를 통해 검색하고, 이를 반환`)
- 관련 메소드 추가 및 비즈니스 로직 작성

## To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- API 테스트 결과 (`keyword = 그림`)
- ![image](https://github.com/user-attachments/assets/cb1974aa-b837-4019-abc4-c111ff2f726b)
- ![스크린샷 2025-06-27 002225](https://github.com/user-attachments/assets/f70e10c7-c834-4dbf-b37d-1e36e9c5c4ca)
